### PR TITLE
fix: Added tracing fix for parallel tool calls

### DIFF
--- a/jaf/core/engine.py
+++ b/jaf/core/engine.py
@@ -865,7 +865,8 @@ async def _execute_tool_calls(
                 tool_name=tool_call.function.name,
                 args=_try_parse_json(tool_call.function.arguments),
                 trace_id=state.trace_id,
-                run_id=state.run_id
+                run_id=state.run_id,
+                call_id=tool_call.id
             ))))
 
         try:
@@ -891,7 +892,8 @@ async def _execute_tool_calls(
                         trace_id=state.trace_id,
                         run_id=state.run_id,
                         status='error',
-                        tool_result={'error': 'tool_not_found'}
+                        tool_result={'error': 'tool_not_found'},
+                        call_id=tool_call.id
                     ))))
 
                 return {
@@ -925,7 +927,8 @@ async def _execute_tool_calls(
                         trace_id=state.trace_id,
                         run_id=state.run_id,
                         status='error',
-                        tool_result={'error': 'validation_error', 'details': e.errors()}
+                        tool_result={'error': 'validation_error', 'details': e.errors()},
+                        call_id=tool_call.id
                     ))))
 
                 return {
@@ -1063,7 +1066,8 @@ async def _execute_tool_calls(
                         trace_id=state.trace_id,
                         run_id=state.run_id,
                         status='timeout',
-                        tool_result={'error': 'timeout_error'}
+                        tool_result={'error': 'timeout_error'},
+                        call_id=tool_call.id
                     ))))
 
                 return {
@@ -1115,7 +1119,8 @@ async def _execute_tool_calls(
                     trace_id=state.trace_id,
                     run_id=state.run_id,
                     tool_result=tool_result,
-                    status='success'
+                    status='success',
+                    call_id=tool_call.id
                 ))))
 
             # Check for handoff
@@ -1153,7 +1158,8 @@ async def _execute_tool_calls(
                     trace_id=state.trace_id,
                     run_id=state.run_id,
                     status='error',
-                    tool_result={'error': 'execution_error', 'detail': str(error)}
+                    tool_result={'error': 'execution_error', 'detail': str(error)},
+                    call_id=tool_call.id
                 ))))
 
             return {

--- a/jaf/core/types.py
+++ b/jaf/core/types.py
@@ -541,11 +541,12 @@ class ToolCallStartEventData:
     args: Any
     trace_id: TraceId
     run_id: RunId
+    call_id: Optional[str] = None
 
 @dataclass(frozen=True)
 class ToolCallStartEvent:
     type: Literal['tool_call_start'] = 'tool_call_start'
-    data: ToolCallStartEventData = field(default_factory=lambda: ToolCallStartEventData("", None, TraceId(""), RunId("")))
+    data: ToolCallStartEventData = field(default_factory=lambda: ToolCallStartEventData("", None, TraceId(""), RunId(""), None))
 
 @dataclass(frozen=True)
 class ToolCallEndEventData:
@@ -556,11 +557,12 @@ class ToolCallEndEventData:
     run_id: RunId
     tool_result: Optional[Any] = None
     status: Optional[str] = None
+    call_id: Optional[str] = None
 
 @dataclass(frozen=True)
 class ToolCallEndEvent:
     type: Literal['tool_call_end'] = 'tool_call_end'
-    data: ToolCallEndEventData = field(default_factory=lambda: ToolCallEndEventData("", "", TraceId(""), RunId("")))
+    data: ToolCallEndEventData = field(default_factory=lambda: ToolCallEndEventData("", "", TraceId(""), RunId(""), None, None))
 
 @dataclass(frozen=True)
 class HandoffEventData:


### PR DESCRIPTION
Introduced stable per-tool `call_id` propagation so parallel executions emit distinct telemetry spans and streaming updates. Key updates:
- `local-dependencies/jaf-py/jaf/core/types.py:538` adds optional `call_id` fields to tool start/end event payloads.
- `local-dependencies/jaf-py/jaf/core/engine.py:864` now emits the tool call id on every start/end event so downstream collectors can correlate results.
- `local-dependencies/jaf-py/jaf/core/tracing.py:652` captures the new id, generates synthetic ids when missing, and keys Langfuse OTEL spans by trace + call id to avoid collisions.
- `local-dependencies/jaf-py/jaf/core/streaming.py:212` tracks in-flight tool calls by id and defaults to a generated id when the model omits one, keeping streaming tool results aligned.

Testing:
- `pytest local-dependencies/jaf-py/tests/test_engine.py::test_streaming_tool_call_execution` *(fails: `ModuleNotFoundError` for `opentelemetry` in this environment).*