### PR TITLE
refactor: Update status handling to use 'execution_status' instead of 'status' across multiple components

### DIFF
--- a/adk/runners/agent_runner.py
+++ b/adk/runners/agent_runner.py
@@ -204,9 +204,9 @@ async def call_real_llm_with_tools(
                                         break
                             if tool:
                                 tool_result = {
-                                    'success': event['data'].get('status', 'success') == 'success',
+                                    'success': event['data'].get('execution_status', 'success') == 'success',
                                     'data': event['data']['result'],
-                                    'error': None if event['data'].get('status', 'success') == 'success' else event['data']['result']
+                                    'error': None if event['data'].get('execution_status', 'success') == 'success' else event['data']['result']
                                 }
                                 await callbacks.on_after_tool_execution(tool, tool_result)
                 
@@ -454,8 +454,8 @@ async def execute_agent(
                             'id': function_call['id'],
                             'name': function_call['name'],
                             'response': matching_end_event['data']['result'],
-                            'success': matching_end_event['data'].get('status', 'success') == 'success',
-                            'error': None if matching_end_event['data'].get('status', 'success') == 'success' else matching_end_event['data']['result']
+                            'success': matching_end_event['data'].get('execution_status', 'success') == 'success',
+                            'error': None if matching_end_event['data'].get('execution_status', 'success') == 'success' else matching_end_event['data']['result']
                         }
                         tool_responses.append(function_response)
                         

--- a/adk/runners/tests/test_agent_runner_deep.py
+++ b/adk/runners/tests/test_agent_runner_deep.py
@@ -242,7 +242,7 @@ class TestAdvancedControlFlow:
                 end_event.data = {
                     'tool_name': 'search_tool',
                     'result': '{"results": "data"}',
-                    'status': 'success'
+                    'execution_status': 'success'
                 }
                 type(end_event).__name__ = 'ToolCallEndEvent'
                 run_config.on_event(end_event)
@@ -430,7 +430,7 @@ class TestAgentHooks:
                 end_event.data = {
                     'tool_name': 'search_tool',
                     'result': '{"results": "data", "contexts": [{"id": "original_ctx", "content": "Original content"}]}',
-                    'status': 'success'
+                    'execution_status': 'success'
                 }
                 type(end_event).__name__ = 'ToolCallEndEvent'
                 run_config.on_event(end_event)

--- a/jaf/core/engine.py
+++ b/jaf/core/engine.py
@@ -1011,7 +1011,7 @@ async def _execute_tool_calls(
 
             if not tool:
                 error_result = json.dumps({
-                    'status': 'tool_not_found',
+                    'hitl_status': 'tool_not_found',  # HITL workflow status
                     'message': f'Tool {tool_call.function.name} not found',
                     'tool_name': tool_call.function.name,
                 })
@@ -1022,7 +1022,7 @@ async def _execute_tool_calls(
                         result=error_result,
                         trace_id=state.trace_id,
                         run_id=state.run_id,
-                        status='error',
+                        execution_status='error',  # Tool execution failed
                         tool_result={'error': 'tool_not_found'},
                         call_id=tool_call.id
                     ))))
@@ -1045,7 +1045,7 @@ async def _execute_tool_calls(
                     validated_args = raw_args
             except ValidationError as e:
                 error_result = json.dumps({
-                    'status': 'validation_error',
+                    'hitl_status': 'validation_error',  # HITL workflow status
                     'message': f'Invalid arguments for {tool_call.function.name}: {e!s}',
                     'tool_name': tool_call.function.name,
                     'validation_errors': e.errors()
@@ -1057,7 +1057,7 @@ async def _execute_tool_calls(
                         result=error_result,
                         trace_id=state.trace_id,
                         run_id=state.run_id,
-                        status='error',
+                        execution_status='error',  # Tool execution failed due to validation
                         tool_result={'error': 'validation_error', 'details': e.errors()},
                         call_id=tool_call.id
                     ))))
@@ -1114,7 +1114,7 @@ async def _execute_tool_calls(
                 
                 # Return interrupted result with halted message
                 halted_result = json.dumps({
-                    'status': 'halted',
+                    'hitl_status': 'pending_approval',  # HITL workflow status: waiting for approval
                     'message': f'Tool {tool_call.function.name} requires approval.',
                 })
                 
@@ -1131,7 +1131,7 @@ async def _execute_tool_calls(
             if derived_status == 'rejected':
                 rejection_reason = approval_status.additional_context.get('rejection_reason', 'User declined the action') if approval_status.additional_context else 'User declined the action'
                 rejection_result = json.dumps({
-                    'status': 'approval_denied',
+                    'hitl_status': 'rejected',  # HITL workflow status: user rejected the action
                     'message': f'Action was not approved. {rejection_reason}. Please ask if you can help with something else or suggest an alternative approach.',
                     'tool_name': tool_call.function.name,
                     'rejection_reason': rejection_reason,
@@ -1184,7 +1184,7 @@ async def _execute_tool_calls(
                 )
             except asyncio.TimeoutError:
                 timeout_error_result = json.dumps({
-                    'error': 'timeout_error',
+                    'hitl_status': 'execution_timeout',  # HITL workflow status
                     'message': f'Tool {tool_call.function.name} timed out after {timeout} seconds',
                     'tool_name': tool_call.function.name,
                     'timeout_seconds': timeout
@@ -1196,7 +1196,7 @@ async def _execute_tool_calls(
                         result=timeout_error_result,
                         trace_id=state.trace_id,
                         run_id=state.run_id,
-                        status='timeout',
+                        execution_status='timeout',  # Tool execution timed out
                         tool_result={'error': 'timeout_error'},
                         call_id=tool_call.id
                     ))))
@@ -1222,7 +1222,7 @@ async def _execute_tool_calls(
             # Wrap tool result with status information for approval context
             if approval_status and approval_status.additional_context:
                 final_content = json.dumps({
-                    'status': 'approved_and_executed',
+                    'hitl_status': 'approved_and_executed',  # HITL workflow status: approved by user and executed
                     'result': result_string,
                     'tool_name': tool_call.function.name,
                     'approval_context': approval_status.additional_context,
@@ -1230,14 +1230,14 @@ async def _execute_tool_calls(
                 })
             elif needs_approval:
                 final_content = json.dumps({
-                    'status': 'approved_and_executed',
+                    'hitl_status': 'approved_and_executed',  # HITL workflow status: approved by user and executed
                     'result': result_string,
                     'tool_name': tool_call.function.name,
                     'message': 'Tool was approved and executed successfully.'
                 })
             else:
                 final_content = json.dumps({
-                    'status': 'executed',
+                    'hitl_status': 'executed',  # HITL workflow status: executed normally (no approval needed)
                     'result': result_string,
                     'tool_name': tool_call.function.name,
                     'message': 'Tool executed successfully.'
@@ -1250,7 +1250,7 @@ async def _execute_tool_calls(
                     trace_id=state.trace_id,
                     run_id=state.run_id,
                     tool_result=tool_result,
-                    status='success',
+                    execution_status='success',  # Tool execution succeeded
                     call_id=tool_call.id
                 ))))
 
@@ -1277,7 +1277,7 @@ async def _execute_tool_calls(
 
         except Exception as error:
             error_result = json.dumps({
-                'status': 'execution_error',
+                'hitl_status': 'execution_error',  # HITL workflow status
                 'message': str(error),
                 'tool_name': tool_call.function.name,
             })
@@ -1288,7 +1288,7 @@ async def _execute_tool_calls(
                     result=error_result,
                     trace_id=state.trace_id,
                     run_id=state.run_id,
-                    status='error',
+                    execution_status='error',  # Tool execution failed with exception
                     tool_result={'error': 'execution_error', 'detail': str(error)},
                     call_id=tool_call.id
                 ))))

--- a/jaf/core/tracing.py
+++ b/jaf/core/tracing.py
@@ -716,7 +716,7 @@ class LangfuseTraceCollector:
                         "result": tool_result,
                         "call_id": call_id,
                         "timestamp": datetime.now().isoformat(),
-                        "status": event.data.get("status", "completed"),
+                        "execution_status": event.data.get("execution_status", "completed"),
                         "tool_result": event.data.get("tool_result")
                     }
                     
@@ -731,7 +731,7 @@ class LangfuseTraceCollector:
                         "result": tool_result,
                         "call_id": call_id,
                         "timestamp": datetime.now().isoformat(),
-                        "status": event.data.get("status", "completed")
+                        "execution_status": event.data.get("execution_status", "completed")
                     }
                     
                     # End the span with detailed output

--- a/jaf/core/types.py
+++ b/jaf/core/types.py
@@ -619,13 +619,28 @@ class ToolCallStartEvent:
 
 @dataclass(frozen=True)
 class ToolCallEndEventData:
-    """Data for tool call end events."""
+    """
+    Data for tool call end events.
+
+    IMPORTANT: There are two different status concepts:
+    1. execution_status (this field): Indicates whether the tool execution itself succeeded or failed
+       - 'success': Tool executed without errors
+       - 'error': Tool execution failed due to validation, not found, or runtime errors
+       - 'timeout': Tool execution timed out
+
+    2. hitl_status (in result JSON): Indicates HITL workflow status
+       - 'executed': Tool ran normally (no approval needed)
+       - 'approved_and_executed': Tool required approval, was approved, and executed
+       - 'pending_approval': Tool requires approval and is waiting
+       - 'rejected': Tool was rejected by user
+       - 'execution_error', 'validation_error', etc.: Various error states
+    """
     tool_name: str
     result: str
     trace_id: TraceId
     run_id: RunId
     tool_result: Optional[Any] = None
-    status: Optional[str] = None
+    execution_status: Optional[str] = None  # success/error/timeout - indicates if tool executed successfully
     call_id: Optional[str] = None
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This pull request standardizes and clarifies the status fields used in tool execution and HITL (Human-in-the-Loop) workflows across the codebase. The main focus is on consistently using `execution_status` to represent tool execution outcomes and `hitl_status` within result payloads to indicate HITL workflow states. This improves code clarity and reduces ambiguity in status reporting. The most important changes are as follows:

**Status Field Standardization:**

* Replaced all uses of the `status` field with `execution_status` in tool execution results, event handling, and tracing to consistently indicate tool execution outcomes (e.g., success, error, timeout). [[1]](diffhunk://#diff-9b22f31fb107d8fcad992a62c439765f5e962b264035bef8d3f62ebba1865245L207-R209) [[2]](diffhunk://#diff-9b22f31fb107d8fcad992a62c439765f5e962b264035bef8d3f62ebba1865245L457-R458) [[3]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1025-R1025) [[4]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1060-R1060) [[5]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1199-R1199) [[6]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1253-R1253) [[7]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1291-R1291) [[8]](diffhunk://#diff-06a281e2bd0110fe396fac4247f118598f42f91393e92f4daf1427689db53e00L719-R719) [[9]](diffhunk://#diff-06a281e2bd0110fe396fac4247f118598f42f91393e92f4daf1427689db53e00L734-R734) [[10]](diffhunk://#diff-fcd4a8a6f59b19673f983432f4ff7e1ad196f510d183678cdd3575c2699bffbbL622-R643)
* Updated tests and event mocks to use `execution_status` instead of `status` for tool call end events. [[1]](diffhunk://#diff-9ead6fff47aa1235b73966238f1ae86780f84acd88ee64ab3d2a320a4f6b574bL245-R245) [[2]](diffhunk://#diff-9ead6fff47aa1235b73966238f1ae86780f84acd88ee64ab3d2a320a4f6b574bL433-R433)

**HITL Workflow Status Clarification:**

* Introduced and documented the use of `hitl_status` in result payloads to represent HITL workflow states (e.g., executed, approved_and_executed, pending_approval, rejected, validation_error, execution_error, execution_timeout). [[1]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1014-R1014) [[2]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1048-R1048) [[3]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1117-R1117) [[4]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1134-R1134) [[5]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1187-R1187) [[6]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1225-R1240) [[7]](diffhunk://#diff-03f7bbb672d42026177023a73ed14afe3b47cdef344bfed77d68328e80ec9098L1280-R1280)
* Added detailed documentation to the `ToolCallEndEventData` dataclass explaining the distinction between `execution_status` and `hitl_status`.

These changes ensure that the status of tool executions and HITL workflow states are clearly distinguished and consistently represented throughout the system.