### PR TITLE
feat: Add agent_name tagging to LangfuseTraceCollector for improved dashboard filtering

### DIFF
--- a/jaf/core/tracing.py
+++ b/jaf/core/tracing.py
@@ -509,12 +509,12 @@ class LangfuseTraceCollector:
                         "user_id": user_id or event.data.get("user_id")
                     }
                 }
-                
+
                 # Extract agent_name for tagging
                 agent_name = event.data.get("agent_name") or "analytics_agent_jaf"
 
                 trace = self.langfuse.trace(
-                    name=f"jaf-run-{trace_id}",
+                    name=agent_name,
                     user_id=user_id or event.data.get("user_id"),
                     session_id=event.data.get("session_id"),
                     input=trace_input,
@@ -537,7 +537,6 @@ class LangfuseTraceCollector:
                 trace._user_id = user_id or event.data.get("user_id")
                 trace._user_query = user_query
                 trace._conversation_history = conversation_history
-                trace._agent_name = agent_name
                 print(f"[LANGFUSE] Created trace with user query: {user_query[:100] if user_query else 'None'}...")
                 
             elif event.type == "run_end":
@@ -546,16 +545,13 @@ class LangfuseTraceCollector:
                     
                     # Update the trace metadata with final tool calls and results
                     conversation_history = getattr(self.trace_spans[trace_id], '_conversation_history', [])
-                    # Extract agent_name for consistency
-                    agent_name = getattr(self.trace_spans[trace_id], '_agent_name', None) or event.data.get("agent_name") or "analytics_agent_jaf"
-
                     final_metadata = {
                         "framework": "jaf",
                         "event_type": "run_end",
                         "trace_id": str(trace_id),
                         "user_query": getattr(self.trace_spans[trace_id], '_user_query', None),
                         "user_id": getattr(self.trace_spans[trace_id], '_user_id', None),
-                        "agent_name": agent_name,
+                        "agent_name": event.data.get("agent_name", "analytics_agent_jaf"),
                         "conversation_history": conversation_history,
                         "tool_calls": self.trace_tool_calls.get(trace_id, []),
                         "tool_results": self.trace_tool_results.get(trace_id, [])

--- a/jaf/core/tracing.py
+++ b/jaf/core/tracing.py
@@ -510,18 +510,22 @@ class LangfuseTraceCollector:
                     }
                 }
                 
+                # Extract agent_name for tagging
+                agent_name = event.data.get("agent_name", "analytics_agent_jaf")
+
                 trace = self.langfuse.trace(
                     name=f"jaf-run-{trace_id}",
                     user_id=user_id or event.data.get("user_id"),
                     session_id=event.data.get("session_id"),
                     input=trace_input,
+                    tags=[agent_name],  # Add agent_name as a tag for dashboard filtering
                     metadata={
                         "framework": "jaf",
                         "event_type": "run_start",
                         "trace_id": str(trace_id),
                         "user_query": user_query,
                         "user_id": user_id or event.data.get("user_id"),
-                        "agent_name": event.data.get("agent_name", "analytics_agent_jaf"),
+                        "agent_name": agent_name,
                         "conversation_history": conversation_history,
                         "tool_calls": [],
                         "tool_results": [],
@@ -541,13 +545,16 @@ class LangfuseTraceCollector:
                     
                     # Update the trace metadata with final tool calls and results
                     conversation_history = getattr(self.trace_spans[trace_id], '_conversation_history', [])
+                    # Extract agent_name for consistency
+                    agent_name = event.data.get("agent_name", "analytics_agent_jaf")
+
                     final_metadata = {
                         "framework": "jaf",
                         "event_type": "run_end",
                         "trace_id": str(trace_id),
                         "user_query": getattr(self.trace_spans[trace_id], '_user_query', None),
                         "user_id": getattr(self.trace_spans[trace_id], '_user_id', None),
-                        "agent_name": event.data.get("agent_name", "analytics_agent_jaf"),
+                        "agent_name": agent_name,
                         "conversation_history": conversation_history,
                         "tool_calls": self.trace_tool_calls.get(trace_id, []),
                         "tool_results": self.trace_tool_results.get(trace_id, [])

--- a/jaf/core/tracing.py
+++ b/jaf/core/tracing.py
@@ -511,7 +511,7 @@ class LangfuseTraceCollector:
                 }
                 
                 # Extract agent_name for tagging
-                agent_name = event.data.get("agent_name", "analytics_agent_jaf")
+                agent_name = event.data.get("agent_name") or "analytics_agent_jaf"
 
                 trace = self.langfuse.trace(
                     name=f"jaf-run-{trace_id}",
@@ -537,6 +537,7 @@ class LangfuseTraceCollector:
                 trace._user_id = user_id or event.data.get("user_id")
                 trace._user_query = user_query
                 trace._conversation_history = conversation_history
+                trace._agent_name = agent_name
                 print(f"[LANGFUSE] Created trace with user query: {user_query[:100] if user_query else 'None'}...")
                 
             elif event.type == "run_end":
@@ -546,7 +547,7 @@ class LangfuseTraceCollector:
                     # Update the trace metadata with final tool calls and results
                     conversation_history = getattr(self.trace_spans[trace_id], '_conversation_history', [])
                     # Extract agent_name for consistency
-                    agent_name = event.data.get("agent_name", "analytics_agent_jaf")
+                    agent_name = getattr(self.trace_spans[trace_id], '_agent_name', None) or event.data.get("agent_name") or "analytics_agent_jaf"
 
                     final_metadata = {
                         "framework": "jaf",


### PR DESCRIPTION
This pull request improves the consistency and usability of trace metadata in the `jaf/core/tracing.py` file by standardizing how the `agent_name` is extracted and used. It also adds the `agent_name` as a tag for easier dashboard filtering.

Enhancements to trace metadata and filtering:

* Standardized extraction of `agent_name` from `event.data` (with a default fallback) for both the trace creation and final metadata update, ensuring consistency across the tracing process. [[1]](diffhunk://#diff-06a281e2bd0110fe396fac4247f118598f42f91393e92f4daf1427689db53e00R513-R528) [[2]](diffhunk://#diff-06a281e2bd0110fe396fac4247f118598f42f91393e92f4daf1427689db53e00R548-R557)
* Added `agent_name` as a tag to traces, enabling improved filtering and analysis in the dashboard.